### PR TITLE
Fix broken autoload path

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,6 @@
     "psr-4" : {
       "SonarSoftware\\CustomerPortalFramework\\" : "src"
     },
-    "files": ["Helpers/functions.php"]
+    "files": ["src/Helpers/functions.php"]
   }
 }


### PR DESCRIPTION
This is required for composer to properly generate autoloader paths, otherwise I get errors.