### PR TITLE
contract v1 and v2 compatibility

### DIFF
--- a/src/Models/Contract.php
+++ b/src/Models/Contract.php
@@ -214,7 +214,9 @@ class Contract
 
     public function generateSignatureLink()
     {
-        return getenv('SONAR_URL') . "/contract_signing/" . $this->uniqueLinkKey;
+        $headers = get_headers(getenv('SONAR_URL'),true);
+        $contracts_path = (is_array($headers['Set-Cookie'])) ? "contract" : "contract_signing";
+        return getenv('SONAR_URL') . "/$contracts_path/" . $this->uniqueLinkKey;
     }
 
     /**


### PR DESCRIPTION
In SonarV2, there are two cookies that get set, so in `get_headers(...,true)` it becomes an array. In V1 there is only one cookie that gets set. While this is an effective way of differentiating V1 from V2 _for now_, a better solution would be long-term "proper" way to get the version... perhaps via an http header `Sonar-Version` or something that can be found without having to authenticate. For the customer portal, there already is a user, so testing an API endpoint could also be effective means of identifying the version. Therefore, this PR is is more of a proof-of-concept than a proper long-term solution.