### PR TITLE
Dynamically check instance to see if it's V1 or V2 before returning contract signing URL

### DIFF
--- a/src/Models/Contract.php
+++ b/src/Models/Contract.php
@@ -214,8 +214,8 @@ class Contract
 
     public function generateSignatureLink()
     {
-        $response = get_headers(getenv('SONAR_URL') . "/graphiql")[0];
-        $contracts_path = (strstr($response,"404")) ? "contract_signing" : "contract";
+        $return_code = get_headers(getenv('SONAR_URL') . "/graphiql")[0];
+        $contracts_path = (strstr($return_code,"404")) ? "contract_signing" : "contract";
         return getenv('SONAR_URL') . "/$contracts_path/" . $this->uniqueLinkKey;
     }
 

--- a/src/Models/Contract.php
+++ b/src/Models/Contract.php
@@ -214,7 +214,9 @@ class Contract
 
     public function generateSignatureLink()
     {
-        return getenv('SONAR_URL') . "/contract_signing/" . $this->uniqueLinkKey;
+        $headers = get_headers(getenv('SONAR_URL'),true);
+        $contracts_path = (is_array($headers['Set-Cookie'])) ? "contract" : "contract_signing";
+        return getenv('SONAR_URL') . "/$contracts_path/" . $this->uniqueLinkKey;
     }
 
     /**

--- a/src/Models/Contract.php
+++ b/src/Models/Contract.php
@@ -214,8 +214,8 @@ class Contract
 
     public function generateSignatureLink()
     {
-        $headers = get_headers(getenv('SONAR_URL'),true);
-        $contracts_path = (is_array($headers['Set-Cookie'])) ? "contract" : "contract_signing";
+        $response = get_headers(getenv('SONAR_URL') . "/graphiql")[0];
+        $contracts_path = (strstr($response,"404")) ? "contract_signing" : "contract";
         return getenv('SONAR_URL') . "/$contracts_path/" . $this->uniqueLinkKey;
     }
 


### PR DESCRIPTION
If the site responds with a 404 to https://instance.sonar.software/graphiql it's V1.